### PR TITLE
Use legacy redhat service provider on RedHat platforms

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,3 +1,0 @@
----
-# Debian init scripts actually seem to work
-te_agent::service_enable: true

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,0 +1,5 @@
+---
+# twdaemon does not support chkconfig
+te_agent::service_enable: ~
+# systemctl cannot correctly determine service status
+te_agent::service_provider: redhat

--- a/data/Windows.yaml
+++ b/data/Windows.yaml
@@ -2,6 +2,5 @@
 te_agent::package_install_path: 'C:\Program Files\Tripwire\TE\Agent'
 te_agent::package_name: 'Tripwire Enterprise Agent'
 te_agent::package_provider: windows
-te_agent::service_enable: true
 te_agent::service_name: teagent
 te_agent::service_rtm_name: tesvc

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -18,8 +18,7 @@ te_agent::agent_properties: ~
 te_agent::tags: ~
 te_agent::service_manage: true
 te_agent::service_ensure: running
-# twdaemon does not support chkconfig
-te_agent::service_enable: ~
+te_agent::service_enable: true
 te_agent::service_name: twdaemon
 te_agent::service_provider: ~
 # only makes sense if install_rtm = true

--- a/spec/acceptance/basic_install_spec.rb
+++ b/spec/acceptance/basic_install_spec.rb
@@ -40,9 +40,15 @@ describe 'te_agent install' do
   end
 
   # Agent service installed and running
-  describe service(service_name) do
+  describe service(service_name), :if => os[:family] != 'redhat' do
     it { should be_enabled }
     it { should be_running }
+  end
+
+  # service resource doesn't work correctly on redhat. check process instead.
+  describe process('java'), :if => os[:family] == 'redhat' do
+    it { should be_running }
+    its(:args) { should match /-Dtw\.server=false/ }
   end
 
   # EG service should be installed and running


### PR DESCRIPTION
The default service provider for newer RedHat/CentOS platforms is
systemd, which has problems with the twdaemon init script. Force these
to use the legacy redhat provider instead.

Fixes issue #1