### PR TITLE
Fix the puppet resource package command

### DIFF
--- a/lib/puppet/provider/package/te_agent_bin.rb
+++ b/lib/puppet/provider/package/te_agent_bin.rb
@@ -21,6 +21,10 @@ Puppet::Type.type(:package).provide(:te_agent_bin, :parent => Puppet::Provider::
     end
   end
 
+  def self.instances
+    []
+  end
+
   def query
     version = get_version
     version ? {:ensure => version, :name => resource[:name], :provider => :te_agent_bin} : nil


### PR DESCRIPTION
The command fails if we do not define the instances method.
Fixes #4