### PR TITLE
Update custom provider to return valid package resource info

### DIFF
--- a/lib/puppet/provider/package/te_agent_bin.rb
+++ b/lib/puppet/provider/package/te_agent_bin.rb
@@ -14,9 +14,6 @@ Puppet::Type.type(:package).provide(:te_agent_bin, :parent => Puppet::Provider::
   has_feature :versionable
   has_feature :install_options
 
-  confine :osfamily => [ :RedHat ]
-  confine :exists   => "/etc/init.d/twdaemon"
-
   def self.prefetch(packages)
     packages.each do |name, pkg|
       version = get_version(pkg)
@@ -44,7 +41,6 @@ Puppet::Type.type(:package).provide(:te_agent_bin, :parent => Puppet::Provider::
       new(:name => 'te_agent', :ensure => version, :provider => :te_agent_bin)
     end
   end
-
 
   def query
     version = get_version


### PR DESCRIPTION
I updated the provider to return valid data and made a few other adjustments. The self.instances validates version and installation by starting in the /etc/init.d/twdaemon file where it grabs the working dir, modifies it to pinpoint the version file, and pull the version from the version file. It also returns the name of the package resource as it is defined in the module.  This is to resolve Issue [8](https://github.com/Tripwire/puppet-te_agent/issues/8).